### PR TITLE
Add Python 3.14 support

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
       - name: Checkout code

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,12 +14,17 @@ readme = "README.md"
 
 classifiers = [
   "Development Status :: 5 - Production/Stable",
-  "Programming Language :: Python :: 3",
   "Framework :: Flake8",
   "License :: OSI Approved :: MIT License",
   "Intended Audience :: Developers",
   "Topic :: Software Development :: Libraries :: Python Modules",
   "Typing :: Typed",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
 ]
 
 homepage = "https://github.com/imtoopunkforyou/flake8-digit-separator"


### PR DESCRIPTION

- **Added:** Python 3.14 to the test matrix in GitHub Actions workflow
- **Changed:** Updated package classifiers in pyproject.toml to include specific Python version support (3.10, 3.11, 3.12, 3.13, 3.14) instead of generic "Programming Language :: Python :: 3"
- **Removed:** Generic "Programming Language :: Python :: 3" classifier in favor of specific version classifiers